### PR TITLE
Correcting the coordinates of Popup when Directionality is RTL

### DIFF
--- a/lib/src/popup.dart
+++ b/lib/src/popup.dart
@@ -236,9 +236,15 @@ class _PopupRoute extends PopupRoute<void> {
   Rect? _getRect(GlobalKey key) {
     final currentContext = key.currentContext;
     final renderBox = currentContext?.findRenderObject() as RenderBox?;
-    if (renderBox == null) return null;
+    if (renderBox == null || currentContext == null) return null;
     final offset = renderBox.localToGlobal(renderBox.paintBounds.topLeft);
-    return offset & renderBox.paintBounds.size;
+    var rect = offset & renderBox.paintBounds.size;
+
+    if (Directionality.of(currentContext) == TextDirection.rtl) {
+      rect = Rect.fromLTRB(0, rect.top, rect.right - rect.left, rect.bottom);
+    }
+
+    return rect;
   }
 
   // Calculate the horizontal position of the arrow


### PR DESCRIPTION
When using a Locale that has a directionality of RTL (like Arabic for example), the position of the popup relative to the child is messed up (only horizontally)

The PR recalculates based on the offset that would normally be returned when the Directionality is LTR.

Tested locally, it seems to work now.